### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/AL-BASHA/b185043c-f42e-4d4f-88c4-b087b2b709ba/845a53eb-506f-47c2-811f-267fae4329c2/_apis/work/boardbadge/391467e4-76e4-432d-8986-93733a89eb94)](https://dev.azure.com/AL-BASHA/b185043c-f42e-4d4f-88c4-b087b2b709ba/_boards/board/t/845a53eb-506f-47c2-811f-267fae4329c2/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/AL-BASHA/b185043c-f42e-4d4f-88c4-b087b2b709ba/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.